### PR TITLE
Add anonymous email queue endpoint

### DIFF
--- a/Api/Client/LogsController.cs
+++ b/Api/Client/LogsController.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+using Reshebnik.Domain.Entities;
+using Reshebnik.EntityFramework;
+
+namespace Reshebnik.Web.Api.Client;
+
+[AllowAnonymous]
+[ApiController]
+[ApiExplorerSettings(GroupName = "Client")]
+[Route("api/admin/[controller]")]
+public class LogsController : ControllerBase
+{
+    [HttpGet("emailsQueue")]
+    public async Task<IActionResult> GetEmailsQueueAsync(
+        [FromServices] ReshebnikContext db,
+        CancellationToken cancellationToken)
+    {
+        var emails = await db.EmailQueue
+            .AsNoTracking()
+            .Where(e => !e.IsSent && e.Error == null)
+            .OrderBy(e => e.EnqueuedAt)
+            .ToListAsync(cancellationToken);
+
+        return Ok(emails);
+    }
+}


### PR DESCRIPTION
## Summary
- add `LogsController` in Client API with `emailsQueue` endpoint to inspect unsent emails

## Testing
- `dotnet format Reshebnik.Web.sln --no-restore`
- `dotnet build Reshebnik.Web.sln`

------
https://chatgpt.com/codex/tasks/task_e_6879d8bfcb98832a9ca090ee2bb237cf